### PR TITLE
[8.x] Fix facade isMock to recognise LegacyMockInterface

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -4,7 +4,7 @@ namespace Illuminate\Support\Facades;
 
 use Closure;
 use Mockery;
-use Mockery\MockInterface;
+use Mockery\LegacyMockInterface;
 use RuntimeException;
 
 abstract class Facade
@@ -126,7 +126,7 @@ abstract class Facade
         $name = static::getFacadeAccessor();
 
         return isset(static::$resolvedInstance[$name]) &&
-               static::$resolvedInstance[$name] instanceof MockInterface;
+               static::$resolvedInstance[$name] instanceof LegacyMockInterface;
     }
 
     /**


### PR DESCRIPTION
When attempting to make more than one call to `\Gate::shouldReceive` i experienced a strange error as it was attempting to mock the existing mock on the second call.
After a little investigation it seems that a Mockery mock does not always implement `\Mockery\MockInterface` but may implement `\Mockery\LegacyMockInterface` (which the former extends).

It does this when the class being mocked implements an `allows` (like Gate) or `expects` method to prevent collision.

It would appear that despite the name there is no intention to deprecate or remove this interface as described here https://github.com/mockery/mockery/issues/1019 and thus it would be a better choice to detect any possible mock.
